### PR TITLE
Fix an issue: include and exclude properties from config file always overwritten and not used

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,11 +23,18 @@ async function main() {
     .option('--only-parse', 'Only parses the messages to check')
     .action(async ({config, ...options}) => {
       
-      options.include = options.include ? options.include.split(',') : [];
-      options.exclude = options.exclude ? options.exclude.split(',') : [];
+      if (options.include)
+        options.include = options.include.split(',');
+      if (options.exclude)
+        options.exclude = options.exclude.split(',');
 
       const configFile = config && await fs.promises.readFile(config);
-      const configOptions = configFile ? JSON.parse(configFile) : {};
+      var configOptions = configFile ? JSON.parse(configFile) : {};
+      if (!configOptions.include)
+        configOptions.include = [];
+      if (!configOptions.exclude)
+        configOptions.exclude = [];
+
       const { source, token, serverId, out, include, exclude, parentChannel, onlyParse } = {
         ...configOptions,
         ...options


### PR DESCRIPTION
src/index.js had the following lines:

    options.include = options.include ? options.include.split(',') : [];
    options.exclude = options.exclude ? options.exclude.split(',') : [];

which make options.include and options.exclude defined as array. Later let's suppose that a config file has include and exclude defined. It is parsed:

      const configOptions = configFile ? JSON.parse(configFile) : {};

and later the following code merges both options from command line and from config:

      const { source, token, serverId, out, include, exclude, parentChannel, onlyParse } = {
        ...configOptions,
        ...options
      }

So, include/exclude from command line args always overwrite such properties from config file because they always defined even if not passed as args.